### PR TITLE
feat: migrate testing infrastructure from Mockito to MockK

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -211,8 +211,59 @@ It declares that this module is:
     </dependencyManagement>
 
     <build>
+        <plugins>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.12</version>
+                <executions>
+                    <execution>
+                        <id>prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report-aggregate</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>report-aggregate</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
         <pluginManagement>
             <plugins>
+                <plugin>
+                    <groupId>org.jacoco</groupId>
+                    <artifactId>jacoco-maven-plugin</artifactId>
+                    <version>0.8.12</version>
+
+                    <executions>
+                        <execution>
+                            <id>prepare-agent</id>
+                            <goals>
+                                <goal>prepare-agent</goal>
+                            </goals>
+                        </execution>
+
+                        <execution>
+                            <id>report</id>
+                            <phase>verify</phase>
+                            <goals>
+                                <goal>report</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
 
                 <plugin>
                     <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
Replaced Mockito with MockK (v1.13.8) and SpringMockK (v4.0.2) across the entire project to resolve Kotlin value class limitations and provide more idiomatic Kotlin testing syntax.

Changes:
- Updated parent POM with MockK and SpringMockK dependencies
- Migrated payment-application module (removed Mockito dependencies)
- Migrated payment-infrastructure module (added SpringMockK support)
- Migrated common module (replaced mockito-kotlin with MockK)
- Converted all test files to use MockK syntax:
  * CreatePaymentServiceTest.kt (4 tests)
  * ProcessPaymentServiceTest.kt (14 tests, re-enabled previously failing test)
  * OutboxEventMapperTest.kt (7 integration tests with @MockkBean)

Benefits:
- Resolves Mockito state pollution with Kotlin value classes (PaymentOrderId)
- Native Kotlin support with cleaner syntax (every{}, verify{})
- Better type inference and null handling
- All 123 tests passing (100% success rate)

Documentation:
- Updated README.md with testing strategy and tech stack
- Enhanced docs/architecture.md with new Testing & Quality Assurance section
- Added testing guide to docs/how-to-start.md

Test Results:
- common: 3 tests ✅
- payment-domain: 89 tests ✅
- payment-application: 22 tests ✅
- payment-infrastructure: 9 tests ✅